### PR TITLE
Make the export a named export

### DIFF
--- a/src/donejs-survey-ad.js
+++ b/src/donejs-survey-ad.js
@@ -2,7 +2,7 @@ var Control = require('can-control');
 
 require('./donejs-survey-ad.less');
 
-module.exports = Control.extend({
+exports.SurveyAd = Control.extend({
   defaults: {
     addShowingClassToElement: null,
     engagementCountKey: 'survey-ad-engagement-count',

--- a/src/test.js
+++ b/src/test.js
@@ -4,5 +4,9 @@ import QUnit from 'steal-qunit';
 QUnit.module('donejs-survey-ad');
 
 QUnit.test('Initialized the plugin', function(){
-  QUnit.equal(typeof plugin, 'function');
+  QUnit.equal(typeof plugin, 'object');
+});
+
+QUnit.test('Control exported as SurveyAd', function(){
+	QUnit.equal(typeof plugin.SurveyAd, 'function');
 });


### PR DESCRIPTION
This changes the export of the control to be a named export `SurveyAd`
rather than be the `module.exports` value. This is because bit-docs
greedily calls all functions that are exported by plugins. Making this
be a named export works around that issue.

Note that this is a breaking change, so downstream users will need to be
updated (next time they need to upgrade their survey-ad version that
		is).